### PR TITLE
話数から駅を除去(輪るピングドラム対応)

### DIFF
--- a/src/scripts/hack_fetch_thread.js
+++ b/src/scripts/hack_fetch_thread.js
@@ -159,6 +159,7 @@ function buildSearchWord(title) {
       .replace(/【.*】/, ' ') // 日テレオンデマンド対応
       // 特殊系
       .replace('STEINS;GATE', 'シュタインズ ゲート ') // (シュタゲ対応)
+      .replace(/ (\d+)駅/g, ' $1')  // (輪るピングドラム対応 (第N駅 <-> Nth station ・第は除去済み))
   );
 }
 


### PR DESCRIPTION
以下で動作確認をしました

- http://www.nicovideo.jp/watch/so32206137
- http://www.nicovideo.jp/watch/1509647375
- http://www.nicovideo.jp/watch/so32206260

話数の数字の両側の文字は常に全部 strip してもいいのかもしれない…と思いつつ一応ピンドラ特化の処理にしています。
もしかしたらN駅という表現がタイトルに現れるかもしれないということを考慮して念のため直前の空白をチェックします。

Closes #4 