### PR TITLE
Hotfix/transparency not working

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -10,15 +10,14 @@
   },
   "content_scripts": [
     {
-      "matches": [
-        "*://www.nicovideo.jp/watch/*"
-      ],
-      "js": [
-        "scripts/index.js"
-      ]
+      "matches": ["*://www.nicovideo.jp/watch/*"],
+      "js": ["scripts/index.js"]
     }
   ],
-  "web_accessible_resources": ["scripts/hack_fetch_thread.js"],
+  "web_accessible_resources": [
+    "scripts/hack_fetch_thread.js",
+    "scripts/hack_comment_alpha.js"
+  ],
   "background": {
     "scripts": ["scripts/background.js"]
   },

--- a/src/scripts/hack_comment_alpha.js
+++ b/src/scripts/hack_comment_alpha.js
@@ -1,0 +1,54 @@
+import CommentAlphaStorage from "./modules/storage/comment_alpha_storage";
+
+let addThreadProcessorsEventListenerHacked = false;
+
+let chunkwatchPush = window['webpackChunkwatch'].push;
+window['webpackChunkwatch'].push = function (item) {
+  hackLibrary(item[1]);
+  chunkwatchPush.call(this, ...arguments);
+}
+
+function hackLibrary(libraryFunctions) {
+  if (!addThreadProcessorsEventListenerHacked) {
+    addThreadProcessorsEventListenerHacked = hackAddThreadProcessorsEventListener(libraryFunctions);
+  }
+}
+
+function hackAddThreadProcessorsEventListener(libraryFunctions) {
+  ///////////////////////
+  // _addThreadProcessorsEventListener を書き換える
+
+  const addThreadProcessorsEventListenerFunctionIndex = Object.keys(libraryFunctions).find((index) => {
+    const item = libraryFunctions[index];
+
+    return (
+      item &&
+      !!item.toString().match(/_addThreadProcessorsEventListener\(\w\)\s?\{/)
+    );
+  });
+  if (typeof addThreadProcessorsEventListenerFunctionIndex === 'undefined') {
+    return false;
+  }
+
+  const commentAlpha = CommentAlphaStorage.get();
+
+  const libraryFunction = libraryFunctions[addThreadProcessorsEventListenerFunctionIndex];
+  libraryFunctions[addThreadProcessorsEventListenerFunctionIndex] = function (t, e, n) {
+    libraryFunction(t, e, n);
+    const originalAddThreadProcessorsEventListener = t.exports.default.prototype._addThreadProcessorsEventListener;
+    t.exports.default.prototype._addThreadProcessorsEventListener = function (threads) {
+      // 元処理
+      originalAddThreadProcessorsEventListener.call(this, ...arguments);
+      // コメント描画が半透明に指定されている thread に対して、
+      // commentAlpha をアルファ値（透明度）として利用するよう変更する
+      for (const t of threads) {
+        if (t.layer.isTranslucent) {
+          const e = this.renderer.getLayerEffectControl(t.processor);
+          e.alpha = commentAlpha;
+        }
+      }
+    };
+  };
+
+  return true;
+}

--- a/src/scripts/hack_fetch_thread.js
+++ b/src/scripts/hack_fetch_thread.js
@@ -1,17 +1,13 @@
 import VideoInfo from './modules/video_info';
 import FetchThreadArguments from "./modules/fetch_thread_arguments";
-import SearchAPI from "./modules/search_api";
 import buildSearchWord from "./modules/build_search_word";
 import IgnoreIdsStorage from "./modules/storage/ignore_ids_storage";
 import Dialog from "./modules/dialog";
 import SelectedPairsStorage from "./modules/storage/selected_pairs_storage";
-import CommentAlphaStorage from "./modules/storage/comment_alpha_storage";
 import {GlobalVars} from './modules/global_vars';
 import CommentOffsetStorage from './modules/storage/comment_offset_storage';
 
 let fetchThreadHacked = false;
-//let renderCanvasHacked = false;
-let addThreadProcessorsEventListenerHacked = false;
 
 try {
   init();
@@ -36,12 +32,6 @@ window['webpackChunkwatch'].push = function (item) {
 function hackLibrary(libraryFunctions) {
   if (!fetchThreadHacked) {
     fetchThreadHacked = hackFetchThread(libraryFunctions);
-  }
-  //if (!renderCanvasHacked) {
-  //  renderCanvasHacked = hackRenderCanvas(libraryFunctions);
-  //}
-  if (!addThreadProcessorsEventListenerHacked) {
-    addThreadProcessorsEventListenerHacked = hackAddThreadProcessorsEventListener(libraryFunctions);
   }
 }
 
@@ -308,86 +298,6 @@ function hackFetchThread(libraryFunctions) {
       '#ea5632'
     );
   }
-
-  return true;
-}
-
-//function hackRenderCanvas(libraryFunctions) {
-//  ///////////////////////
-//  // _renderCanvas を書き換える
-//
-//  const renderCanvasFunctionIndex = Object.keys(libraryFunctions).find((index) => {
-//    const item = libraryFunctions[index];
-//    // _renderCanvas の定義とか globalAlpha の設定箇所があったらそれが、コメントをcanvasレンダリングするライブラリ
-//    return (
-//      item &&
-//      !!item.toString().match(/\.prototype\._renderCanvas\s?=\s?function/) &&
-//      !!item.toString().match(/\.context\.globalAlpha\s?=\s?this\.worldAlpha/) &&
-//      !!item.toString().match(/texture\.crop\.width/)
-//    );
-//  });
-//  if (typeof renderCanvasFunctionIndex === 'undefined') {
-//    return false;
-//  }
-//
-//  const commentAlpha = CommentAlphaStorage.get();
-//  
-//  const libraryFunction = libraryFunctions[renderCanvasFunctionIndex];
-//  libraryFunctions[renderCanvasFunctionIndex] = function (t, e, n) {
-//    libraryFunction(t, e, n);
-//    const originalRenderCanvas = t.exports.prototype._renderCanvas;
-//    t.exports.prototype._renderCanvas = function (t) {
-//      // この時点で this.worldAlpha に指定されているアルファ値でコメントがレンダリングされる
-//      // dアニメの動画を見た時、
-//      // dアニメ側のコメントを表示しているチャンネルコメントは this.worldAlpha === 1
-//      // 別動画のコメントを表示している通常コメントは this.worldAlpha === 0.5
-//      if (this.worldAlpha === 0.5) {
-//        this.worldAlpha = commentAlpha;
-//      }
-//      originalRenderCanvas.call(this, ...arguments);
-//    };
-//  };
-//
-//  return true;
-//}
-
-
-function hackAddThreadProcessorsEventListener(libraryFunctions) {
-  ///////////////////////
-  // _addThreadProcessorsEventListener を書き換える
-
-  const addThreadProcessorsEventListenerFunctionIndex = Object.keys(libraryFunctions).find((index) => {
-    const item = libraryFunctions[index];
-
-    return (
-      item &&
-      !!item.toString().match(/_addThreadProcessorsEventListener\(\w\)\s?\{/)
-    );
-  });
-  if (typeof addThreadProcessorsEventListenerFunctionIndex === 'undefined') {
-    return false;
-  }
-
-  const commentAlpha = CommentAlphaStorage.get();
-
-  const libraryFunction = libraryFunctions[addThreadProcessorsEventListenerFunctionIndex];
-  libraryFunctions[addThreadProcessorsEventListenerFunctionIndex] = function (t, e, n) {
-    libraryFunction(t, e, n);
-    const originalAddThreadProcessorsEventListener = t.exports.default.prototype._addThreadProcessorsEventListener;
-    t.exports.default.prototype._addThreadProcessorsEventListener = function (threads) {
-      //originalAddThreadProcessorsEventListener(threads);
-      // 元処理
-      originalAddThreadProcessorsEventListener.call(this, ...arguments);
-      // コメント描画を半透明指定されている thread に対して、
-      // commentAlpha をアルファ値として利用するよう変更する
-      for (const t of threads) {
-        if (t.layer.isTranslucent) {
-          const e = this.renderer.getLayerEffectControl(t.processor);
-          e.alpha = commentAlpha;
-        }
-      }
-    };
-  };
 
   return true;
 }

--- a/src/scripts/index.js
+++ b/src/scripts/index.js
@@ -7,9 +7,23 @@ import CommentOffsetStorage from './modules/storage/comment_offset_storage';
 
 SelectedPairsStorage.migration();
 
-inject(chrome.extension.getURL('scripts/hack_fetch_thread.js'));
+
+const hackScript = createScript(chrome.extension.getURL('scripts/hack_fetch_thread.js'));
+//createScript(chrome.extension.getURL('scripts/hack_fetch_thread.js'));
 const watchAppJsURI = getWatchAppJsURI();
-inject(`${watchAppJsURI}${watchAppJsURI.indexOf('?') === -1 ? '?' : '&'}by-danime-another-comment`);
+const newAppScript = createScript(`${watchAppJsURI}${watchAppJsURI.indexOf('?') === -1 ? '?' : '&'}by-danime-another-comment`);
+//createScript(`${watchAppJsURI}${watchAppJsURI.indexOf('?') === -1 ? '?' : '&'}by-danime-another-comment`);
+
+// 動的追加したスクリプトは非同期に読み込まれるので、onload を用いて同期に読み込ませる
+//hackScript.onload = function() {
+//  document.body.appendChild(newAppScript);
+//}
+//document.body.appendChild(hackScript);
+
+newAppScript.onload = function() {
+  document.body.appendChild(hackScript);
+}
+document.body.appendChild(newAppScript);
 
 // background.js と通信するためのもの
 chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
@@ -105,12 +119,14 @@ window.addEventListener('message', event => {
 });
 
 // --- utils ---
-function inject(src) {
+function createScript(src) {
   const s = document.createElement('script');
   s.setAttribute('type', 'text/javascript');
   s.setAttribute('src', src);
+  return s;
 
-  document.body.appendChild(s);
+  // DEBUG
+  //document.body.appendChild(s);
 }
 
 function getWatchAppJsURI() {

--- a/src/scripts/index.js
+++ b/src/scripts/index.js
@@ -7,23 +7,21 @@ import CommentOffsetStorage from './modules/storage/comment_offset_storage';
 
 SelectedPairsStorage.migration();
 
-
-const hackScript = createScript(chrome.extension.getURL('scripts/hack_fetch_thread.js'));
-//createScript(chrome.extension.getURL('scripts/hack_fetch_thread.js'));
+const hackFetchThreadScript = createScript(chrome.extension.getURL('scripts/hack_fetch_thread.js'));
+const hackCommentAlphaScript = createScript(chrome.extension.getURL('scripts/hack_comment_alpha.js'));
 const watchAppJsURI = getWatchAppJsURI();
 const newAppScript = createScript(`${watchAppJsURI}${watchAppJsURI.indexOf('?') === -1 ? '?' : '&'}by-danime-another-comment`);
-//createScript(`${watchAppJsURI}${watchAppJsURI.indexOf('?') === -1 ? '?' : '&'}by-danime-another-comment`);
 
-// 動的追加したスクリプトは非同期に読み込まれるので、onload を用いて同期に読み込ませる
-//hackScript.onload = function() {
-//  document.body.appendChild(newAppScript);
-//}
-//document.body.appendChild(hackScript);
-
+// 動的追加したスクリプトは非同期に読み込まれるので、onload を用いて同期に読み込ませる。
+// 以下の順にスクリプトを読み込ませないと書き換えたライブラリが参照されなかった。
+// hack_fetch_thread.js, watch_app_*?by-danime-another-comment.js, hack_comment_alpha.js
 newAppScript.onload = function() {
-  document.body.appendChild(hackScript);
+  document.body.appendChild(hackCommentAlphaScript);
 }
-document.body.appendChild(newAppScript);
+hackFetchThreadScript.onload = function() {
+  document.body.appendChild(newAppScript);
+}
+document.body.appendChild(hackFetchThreadScript);
 
 // background.js と通信するためのもの
 chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
@@ -124,9 +122,6 @@ function createScript(src) {
   s.setAttribute('type', 'text/javascript');
   s.setAttribute('src', src);
   return s;
-
-  // DEBUG
-  //document.body.appendChild(s);
 }
 
 function getWatchAppJsURI() {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -3,6 +3,7 @@ module.exports = {
   entry: {
     'index': './index.js',
     'hack_fetch_thread': './hack_fetch_thread.js',
+    'hack_comment_alpha': './hack_comment_alpha.js',
     'background': './background.js',
     'popup': './popup.js'
   },


### PR DESCRIPTION
Close #26 
該当Issueについて修正を行い、こちらの環境で透明度指定が正常にすることまで確認しました。
修正方針としてはざっくり以下です。
- スクリプトの読み込み順が確実に`hack_fetch_thread.js`, `watch_app_...?by-danime-another-comment.js`となるように
  - ※DOMに追記するだけだと非同期読み込みとなるようです。たまに逆順で読み込まれ正常に動作しないパターンが発生していました。
- `7_1b8ca....js`中の`_addThreadProcessorsEventListener`メソッドを書き換え
  - `isTranslucent`フラグが指定されている場合のみポップアップで指定したアルファ値を設定するように
  - 後述する問題のため別途`hack_comment_alpha.js`を追加しそこに書き換え処理を記述
- 最終的にスクリプトを`hack_fetch_thread.js`, `watch_app_...?by-danime-another-comments.js`, `hack_comment_alpha.js`の順で読み込むように
  - `_addThreadProcessorsEventListener`メソッドの書き換え処理を`hack_fetch_thread.js`内に記述した場合、書き換えたメソッドが参照されない問題が発生
  - 上記の順序で読み込ませた場合はなぜか正常に動作するため、この順序で読み込ませる

Webpackの挙動について自分の理解が足りないため、書き換え処理のタイミングがブラックボックス化してしまっています。
ただ、自分が確認した限りでは通常コメント、引用コメント共に透明度指定が正常に機能しているようなのでプルリクを投げました。
お忙しい中恐縮ですが、レビューしていただければと思います。